### PR TITLE
Add awaiting method to support multiple threads

### DIFF
--- a/testing-ktx/src/test/java/com/jraska/livedata/example/CounterViewModel.kt
+++ b/testing-ktx/src/test/java/com/jraska/livedata/example/CounterViewModel.kt
@@ -2,12 +2,15 @@ package com.jraska.livedata.example
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import java.util.concurrent.atomic.AtomicInteger
 
 class CounterViewModel {
   private val counterData = MutableLiveData<Int>()
+  private val labelData = MutableLiveData<String>()
+  private val counter = AtomicInteger()
 
   init {
-    counterData.value = 0
+    counterData.value = counter.get()
   }
 
   fun counterLiveData(): LiveData<Int> {
@@ -15,13 +18,22 @@ class CounterViewModel {
   }
 
   fun plusButtonClicked() {
-    counterData.value = counterData.value!! + 1
+    counterData.value = counter.incrementAndGet()
   }
 
   fun minusButtonClicked() {
-    val value = counterData.value!!
+    counterData.value = counter.decrementAndGet()
+  }
 
-    if (value > 0)
-      counterData.value = value - 1
+  fun counterLabel(): LiveData<String> {
+    return labelData
+  }
+
+  fun asyncUpdateLabel(label: String) {
+    val runnable = Runnable {
+      Thread.sleep(10)
+      labelData.postValue(label) }
+
+    Thread(runnable).start()
   }
 }

--- a/testing-ktx/src/test/java/com/jraska/livedata/example/ExampleJavaTest.java
+++ b/testing-ktx/src/test/java/com/jraska/livedata/example/ExampleJavaTest.java
@@ -98,4 +98,25 @@ public class ExampleJavaTest {
     // Potential remove needs to be handled by you
     viewModel.counterLiveData().removeObserver(testObserver);
   }
+
+  @Test
+  public void awaitAsyncValue() throws InterruptedException {
+    LiveData<String> labelData = viewModel.counterLabel();
+
+    TestObserver<String> testObserver = TestObserver.test(labelData)
+      .assertNoValue();
+
+    viewModel.asyncUpdateLabel("initial");
+
+    testObserver.assertNoValue()
+      .awaitValue()
+      .assertHasValue();
+
+    viewModel.asyncUpdateLabel("different");
+
+    testObserver
+      .assertValue("initial")
+      .awaitNextValue()
+      .assertValue("different");
+  }
 }

--- a/testing-ktx/src/test/java/com/jraska/livedata/example/ExampleTest.kt
+++ b/testing-ktx/src/test/java/com/jraska/livedata/example/ExampleTest.kt
@@ -83,4 +83,24 @@ class ExampleTest {
     testObserver.dispose()
     assertThat(viewModel.counterLiveData().hasObservers()).isFalse()
   }
+
+  @Test
+  fun awaitAsyncValue() {
+    val testObserver = viewModel.counterLabel()
+      .test()
+      .assertNoValue()
+
+    viewModel.asyncUpdateLabel("initial")
+
+    testObserver.assertNoValue()
+      .awaitValue()
+      .assertHasValue()
+
+    viewModel.asyncUpdateLabel("different")
+
+    testObserver
+      .assertValue("initial")
+      .awaitNextValue()
+      .assertValue("different")
+  }
 }


### PR DESCRIPTION
Initially, I wanted to skip these methods from RxJava TestObserver/TestSubscriber, but I already encountered use case for it and iosched app convinced me it can be useful.

https://github.com/google/iosched/blob/master/androidTest-shared/src/main/java/com/google/samples/apps/iosched/androidtest/util/LiveDataTestUtil.kt