### PR TITLE
Publish only compile transitive dependencies with updated maven plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     classpath 'com.android.tools.build:gradle:3.2.1'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
-    classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
+    classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
   }
 }
 

--- a/gradle/installv1.gradle
+++ b/gradle/installv1.gradle
@@ -37,5 +37,14 @@ install {
         }
       }
     }
+
+    // Publish only compile dependencies,
+    // because by default all scopes including test ones
+    // are pulled by transitive dependencies without this code
+    pom.whenConfigured {
+      p -> p.dependencies = p.dependencies.findAll {
+        dep -> dep.scope == "compile"
+      }
+    }
   }
 }


### PR DESCRIPTION
It was making clients to pull all dependencies even testing ones