### PR TITLE
Add hook for onChanged value

### DIFF
--- a/testing-ktx/src/test/java/com/jraska/livedata/example/ExampleJavaTest.java
+++ b/testing-ktx/src/test/java/com/jraska/livedata/example/ExampleJavaTest.java
@@ -1,7 +1,6 @@
 package com.jraska.livedata.example;
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
-import androidx.arch.core.util.Function;
 import androidx.lifecycle.LiveData;
 import com.jraska.livedata.TestLifecycle;
 import com.jraska.livedata.TestObserver;
@@ -31,6 +30,7 @@ public class ExampleJavaTest {
     TestObserver.test(liveData)
       .assertHasValue()
       .assertHistorySize(1)
+      .doOnChanged(value -> assertThat(value).isPositive())
       .assertNever(value -> value > 0);
 
     for (int i = 0; i < 4; i++) {

--- a/testing/src/main/java/com/jraska/livedata/TestObserver.java
+++ b/testing/src/main/java/com/jraska/livedata/TestObserver.java
@@ -14,7 +14,7 @@ import java.util.concurrent.TimeUnit;
 
 public final class TestObserver<T> implements Observer<T> {
   private final List<T> valueHistory = new ArrayList<>();
-  private final List<Consumer<T>> onChangedConsumers = new ArrayList<>();
+  private final List<Consumer<T>> onChanged = new ArrayList<>();
   private CountDownLatch valueLatch = new CountDownLatch(1);
 
   private TestObserver() {
@@ -25,7 +25,7 @@ public final class TestObserver<T> implements Observer<T> {
     valueHistory.add(value);
     valueLatch.countDown();
 
-    for (Consumer<T> consumer : onChangedConsumers) {
+    for (Consumer<T> consumer : onChanged) {
       consumer.accept(value);
     }
   }
@@ -167,7 +167,7 @@ public final class TestObserver<T> implements Observer<T> {
       newObserver.onChanged(mapper.apply(value));
     }
 
-    onValueChanged(new Map<>(newObserver, mapper));
+    doOnChanged(new Map<>(newObserver, mapper));
 
     return newObserver;
   }
@@ -175,11 +175,11 @@ public final class TestObserver<T> implements Observer<T> {
   /**
    * Adds a Consumer which will be triggered on each value change to allow assertion on the value.
    *
-   * @param onObserverValue Consumer to call when new value is received
+   * @param onChanged Consumer to call when new value is received
    * @return this
    */
-  public TestObserver<T> onValueChanged(Consumer<T> onObserverValue) {
-    onChangedConsumers.add(onObserverValue);
+  public TestObserver<T> doOnChanged(Consumer<T> onChanged) {
+    this.onChanged.add(onChanged);
     return this;
   }
 

--- a/testing/src/test/java/com/jraska/livedata/TestObserverTest.kt
+++ b/testing/src/test/java/com/jraska/livedata/TestObserverTest.kt
@@ -143,7 +143,7 @@ class TestObserverTest {
 
     TestObserver.test(testLiveData)
       .map { it * 2 }
-      .onValueChanged { triggeredCount.incrementAndGet() }
+      .doOnChanged { triggeredCount.incrementAndGet() }
 
     val expectedTriggerCount = 10
     repeat(expectedTriggerCount) {
@@ -200,7 +200,7 @@ class TestObserverTest {
   fun whenOnValueChanged_thenFailsProperly() {
     TestObserver.test(testLiveData)
       .map { it * 2 }
-      .onValueChanged { assertThat(it).isEqualTo(1) }
+      .doOnChanged { assertThat(it).isEqualTo(1) }
 
     testLiveData.value = 1
   }

--- a/testing/src/test/java/com/jraska/livedata/TestObserverTest.kt
+++ b/testing/src/test/java/com/jraska/livedata/TestObserverTest.kt
@@ -3,9 +3,11 @@ package com.jraska.livedata
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.ComparisonFailure
 import org.junit.Rule
 import org.junit.Test
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 
 class TestObserverTest {
   @get:Rule val testRule = InstantTaskExecutorRule()
@@ -135,6 +137,22 @@ class TestObserverTest {
     testObserver.map { it.toString() }.assertValue("4")
   }
 
+  @Test
+  fun whenOnValueChanged_thenTriggersProperly() {
+    val triggeredCount = AtomicInteger()
+
+    TestObserver.test(testLiveData)
+      .map { it * 2 }
+      .onValueChanged { triggeredCount.incrementAndGet() }
+
+    val expectedTriggerCount = 10
+    repeat(expectedTriggerCount) {
+      testLiveData.value = 123456
+    }
+
+    assertThat(triggeredCount.get()).isEqualTo(expectedTriggerCount)
+  }
+
   @Test(expected = AssertionError::class)
   fun hasValuesAssertionFailsOnNoValue() {
     TestObserver.test(testLiveData).assertHasValue()
@@ -176,6 +194,15 @@ class TestObserverTest {
     testLiveData.value = 5
 
     testObserver.assertNever { it == 4 }
+  }
+
+  @Test(expected = ComparisonFailure::class)
+  fun whenOnValueChanged_thenFailsProperly() {
+    TestObserver.test(testLiveData)
+      .map { it * 2 }
+      .onValueChanged { assertThat(it).isEqualTo(1) }
+
+    testLiveData.value = 1
   }
 
   private fun setValueAsOne() = Runnable {


### PR DESCRIPTION
Adds list of methods to be called when values changes
This basically duplicated `Observer<T>.onChanged(T)`, however makes the resulting call more fluent than registering separate Observer for any actions

Resolves #35 