### PR TITLE
Add assert value history at index

### DIFF
--- a/testing/src/main/java/com/jraska/livedata/TestObserver.java
+++ b/testing/src/main/java/com/jraska/livedata/TestObserver.java
@@ -154,6 +154,60 @@ public final class TestObserver<T> implements Observer<T> {
   }
 
   /**
+   * Assert that this TestObserver at a specific history index is equal to
+   * the given value.
+   *
+   * @param expected the value to expect being equal to last value, can be null
+   * @return this
+   */
+  public TestObserver<T> assertValueHistoryAt(int index, T expected) {
+    int s = valueHistory.size();
+
+    if (s == 0) {
+      throw fail("No values");
+    }
+
+    if (index >= valueHistory.size()) {
+      throw fail("Invalide index" + index);
+    }
+
+    T value = valueHistory.get(index);
+
+    if (notEquals(value, expected)) {
+      throw fail("Expected: " + valueAndClass(expected) + ", Actual: " + valueAndClass(value));
+    }
+
+    return this;
+  }
+
+  /**
+   * Asserts that for this TestObserver value at a specific history index
+   * the provided predicate returns true.
+   *
+   * @param valuePredicate the predicate that receives the observed value
+   *                       and should return true for the expected value.
+   * @return this
+   */
+  public TestObserver<T> assertValueHistoryAt(int index, @NonNull Function<T, Boolean> valuePredicate) {
+    int s = valueHistory.size();
+
+    if (s == 0) {
+      throw fail("No values");
+    }
+
+    if (index >= valueHistory.size()) {
+      throw fail("Invalid index" + index);
+    }
+
+    if (!valuePredicate.apply(valueHistory.get(index))) {
+      throw fail("Value " + valueAndClass(valueHistory.get(index)) + " does not match the predicate "
+        + valuePredicate.toString() + ".");
+    }
+
+    return this;
+  }
+
+  /**
    * Asserts that this TestObserver did not receive any value for which
    * the provided predicate returns true.
    *
@@ -298,7 +352,8 @@ public final class TestObserver<T> implements Observer<T> {
       this.mapper = mapper;
     }
 
-    @Override public void accept(T value) {
+    @Override
+    public void accept(T value) {
       newObserver.onChanged(mapper.apply(value));
     }
   }

--- a/testing/src/test/java/com/jraska/livedata/TestObserverTest.kt
+++ b/testing/src/test/java/com/jraska/livedata/TestObserverTest.kt
@@ -10,7 +10,8 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
 class TestObserverTest {
-  @get:Rule val testRule = InstantTaskExecutorRule()
+  @get:Rule
+  val testRule = InstantTaskExecutorRule()
 
   private val testLiveData = MutableLiveData<Int>()
 
@@ -31,6 +32,94 @@ class TestObserverTest {
       .assertValueHistory(2, 3, 4, 5)
 
     assertThat(testObserver.valueHistory()).containsExactly(2, 3, 4, 5)
+  }
+
+  @Test
+  fun assertValueHistoryAt() {
+    val testObserver = TestObserver.test(testLiveData)
+
+    testLiveData.apply {
+      value = 1
+      value = null
+      value = 3
+    }
+
+    testObserver.assertHistorySize(3)
+      .assertValueHistoryAt(0, 1)
+      .assertValueHistoryAt(1, null)
+      .assertValueHistoryAt(2, 3)
+
+  }
+
+  @Test(expected = AssertionError::class)
+  fun assertValueHistoryAt_failsOnOtherValue() {
+    val testObserver = TestObserver.test(testLiveData)
+
+    testLiveData.value = 1
+
+    testObserver.assertValueHistoryAt(0, 2)
+
+  }
+
+  @Test(expected = AssertionError::class)
+  fun assertValueHistoryAt_failNoValues() {
+    val testObserver = TestObserver.test(testLiveData)
+
+    testObserver.assertValueHistoryAt(0, 1)
+  }
+
+  @Test(expected = AssertionError::class)
+  fun assertValueHistoryAt_failInvalidIndex() {
+    val testObserver = TestObserver.test(testLiveData)
+
+    testLiveData.value = 1
+
+    testObserver.assertValueHistory(1)
+      .assertValueHistoryAt(1, 1)
+  }
+
+  @Test
+  fun assertValueHistoryAt_valuePredicate() {
+    val testObserver = TestObserver.test(testLiveData)
+
+    testLiveData.apply {
+      value = 1
+      value = null
+      value = 3
+    }
+
+    testObserver.assertHistorySize(3)
+      .assertValueHistoryAt(0) { it == 1 }
+      .assertValueHistoryAt(1) { it == null }
+      .assertValueHistoryAt(2) { it == 3 }
+
+  }
+
+  @Test(expected = AssertionError::class)
+  fun assertValueHistoryAt_valuePredicate_failsOnOtherValue() {
+    val testObserver = TestObserver.test(testLiveData)
+
+    testLiveData.value = 1
+
+    testObserver.assertValueHistoryAt(0) { it == 2 }
+
+  }
+
+  @Test(expected = AssertionError::class)
+  fun assertValueHistoryAt_valuePredicate_failNoValues() {
+    val testObserver = TestObserver.test(testLiveData)
+
+    testObserver.assertValueHistoryAt(0) { it == 1 }
+  }
+
+  @Test(expected = AssertionError::class)
+  fun assertValueHistoryAt_valuePredicate_failInvalidIndex() {
+    val testObserver = TestObserver.test(testLiveData)
+
+    testLiveData.value = 1
+
+    testObserver.assertValueHistory(1)
+      .assertValueHistoryAt(1) { it == 1 }
   }
 
   @Test


### PR DESCRIPTION
This should allow a user to assert the value at a certain index in the LiveData history. I find this quite useful when expecting multiple values from the observable.